### PR TITLE
Fix check in fit-parse

### DIFF
--- a/bin/fit-parse
+++ b/bin/fit-parse
@@ -26,7 +26,7 @@ my $fit_offset = $fit_ptr - $base;
 
 printf "FIT pointer: %08x (offset %08x)\n", $fit_ptr, $fit_offset;
 
-die "FIT pointer out of range?\n" if $fit_offset >= length($rom);
+die "FIT pointer out of range?\n" if $fit_offset < 0;
 
 my $fit = substr($rom, $fit_ptr - $base, 8);
 printf "Signature: '%s'\n", $fit;


### PR DESCRIPTION
The value of fit_offset cannot possibly be greater than the
length of the rom, since fit_ptr is restricted to be 32 bits.
Check instead that the fit_ptr doesn't point outside the rom,
or in other words that fit_offset isn't less than 0.