### PR TITLE
Fix/parallel extract firmware

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ $(BUILD)/%.vol:
 		-o $@ \
 		--size $(or $($(basename $(notdir $@))-size),0x400000) \
 		--compress $(or $($(basename $(notdir $@))-compress),0) \
-		$^
+		$(filter-out extract.intermediate,$^)
 
 create-ffs = \
 	./bin/create-ffs \
@@ -115,9 +115,9 @@ extract.intermediate: $(ROM)
 	$(pwd)/bin/extract-firmware \
 		-o rom \
 	) < $^ \
-	> $(BUILD)/$(BOARD).txt ; \
-
+	> $(BUILD)/$(BOARD).txt
 .INTERMEDIATE: extract.intermediate
+
 
 # All of the output volumes depend on extracting the firmware
 $(patsubst %.vol,,$(FVS)): extract.intermediate

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,7 @@ config:
 	echo 'BOARD ?= $(BOARD)' >> .config
 	echo 'KERNEL ?= $(KERNEL)' >> .config
 	echo 'INITRD ?= $(INITRD)' >> .config
+	echo 'ROM ?= $(ROM)' >> .config
 
 
 # edk2 outputs will be in this deeply nested directory
@@ -94,7 +95,7 @@ $(BUILD)/%.vol:
 		-o $@ \
 		--size $(or $($(basename $(notdir $@))-size),0x400000) \
 		--compress $(or $($(basename $(notdir $@))-compress),0) \
-		$(filter-out extract.intermediate,$^)
+		$(filter-out $(BUILD)/$(BOARD).txt,$^)
 
 create-ffs = \
 	./bin/create-ffs \
@@ -109,19 +110,23 @@ create-ffs = \
 #
 # Extract all of the firmware files from the vendor provided ROM
 #
-extract.intermediate: $(ROM)
+$(BUILD)/$(BOARD).txt: $(ROM)
 	( \
 	cd $(BUILD) ; \
 	$(pwd)/bin/extract-firmware \
 		-o rom \
 	) < $^ \
-	> $(BUILD)/$(BOARD).txt
-.INTERMEDIATE: extract.intermediate
-
+	> $@.tmp
+	mv $@.tmp $@
 
 # All of the output volumes depend on extracting the firmware
-$(patsubst %.vol,,$(FVS)): extract.intermediate
-$(patsubst %.fv,,$(FVS)): extract.intermediate
+$(patsubst %.vol,,$(FVS)): $(BUILD)/$(BOARD).txt
+$(patsubst %.fv,,$(FVS)): $(BUILD)/$(BOARD).txt
+
+# Most of the boards define a $(dxe-files) that are extracted
+# from the vendor ROM. Make sure they depend on the board target
+$(dxe-files): $(BUILD)/$(BOARD).txt
+	@true
 
 $(BUILD)/linuxboot.rom: $(FVS)
 

--- a/boards/monolake/Makefile.board
+++ b/boards/monolake/Makefile.board
@@ -18,8 +18,6 @@ dxe-files := $(shell awk  \
 	boards/$(BOARD)/image-files.txt \
 )
 
-$(dxe-files): extract.intermediate
-
 
 # The Monolake ROM is really fragmented.
 # We could recover osme of the space at 0x8800000

--- a/boards/qemu/Makefile.board
+++ b/boards/qemu/Makefile.board
@@ -25,11 +25,11 @@ dxe-files := $(shell awk  \
 	boards/$(BOARD)/image-files.txt \
 )
 
-$(dxe-files): extract.intermediate
 
 # since the 0.fv is nested inside another FV, we have to add an
 # explicit dependency on the extract target to ensure that it is created
-$(fv-path)/0.fv: extract.intermediate
+$(fv-path)/0.fv: $(BUILD)/$(BOARD).txt
+	@true
 
 FVS := \
 	$(BUILD)/rom/0x00000000.fv \

--- a/boards/r630/Makefile.board
+++ b/boards/r630/Makefile.board
@@ -29,8 +29,6 @@ dxe-files := $(shell awk  \
 	boards/$(BOARD)/image-files.txt \
 )
 
-$(dxe-files): extract.intermediate
-
 
 FVS := \
 $(BUILD)/rom/0x00000000.ifd \

--- a/boards/s2600wf/Makefile.board
+++ b/boards/s2600wf/Makefile.board
@@ -38,33 +38,46 @@ $(dxe-files): extract.intermediate
 # We replace the DXE recovery image and one of the other
 # images with the LinuxBoot one.  Potentially we
 # can clean up more space.
-FVS := \
-$(BUILD)/rom/0x00000000.ifd \
-$(BUILD)/rom/0x00010000.bin \
-$(BUILD)/dxe.vol \
-$(BUILD)/rom/0x03000000.fv \
-$(BUILD)/rom/0x03180000.fv \
-$(BUILD)/rom/0x031a0000.fv \
-$(BUILD)/rom/0x031c0000.fv \
-$(BUILD)/rom/0x031d0000.bin \
-$(BUILD)/rom/0x03200000.fv \
-$(BUILD)/linux.vol \
-$(BUILD)/rom/0x03900000.fv \
-$(BUILD)/rom/0x03a00000.fv \
-$(BUILD)/rom/0x03c00000.fv \
-$(BUILD)/rom/0x03e00000.fv \
-$(BUILD)/rom/0x03e30000.fv \
-$(BUILD)/rom/0x03e80000.fv \
-$(BUILD)/rom/0x03f00000.fv \
-$(BUILD)/rom/0x03f30000.fv \
-$(BUILD)/rom/0x03f80000.fv \
+FVS =
+FVS += $(BUILD)/rom/0x00000000.ifd
+FVS += $(BUILD)/rom/0x00010000.bin  # ME + PDR + DevExp + Gbe + PTT regions
+FVS += $(BUILD)/dxe.vol # Recovery DXE at 0x2C00000
+FVS += $(BUILD)/rom/0x03000000.fv # Empty FV at 0x3000000 (1.5 MB)
+FVS += $(BUILD)/rom/0x03180000.fv # Empty FV (128 KB)
+FVS += $(BUILD)/rom/0x031a0000.fv # Logo FV (128 KB)
+FVS += $(BUILD)/rom/0x031c0000.fv # Empty FV (64 KB)
+FVS += $(BUILD)/rom/0x031d0000.bin # Empty padding (196 KB)
+FVS += $(BUILD)/rom/0x03200000.fv # Empty FV (3 MB)
+FVS += $(BUILD)/linux.vol # Non-recovery DXE, replaced with Linux (4 MB)
+FVS += $(BUILD)/rom/0x03900000.fv # NVRAM (1 MB)
+# FVS += $(BUILD)/rom/0x03a00000.fv # PEI (non-recovery?) (2 MB)
+FVS += $(BUILD)/2mb.fv # an empty FV to replace the unused PEI
+FVS += $(BUILD)/rom/0x03c00000.fv # PEI (2 MB) (recovery won't boot without it)
+FVS += $(BUILD)/rom/0x03e00000.fv # Microcode (196 KB)
+FVS += $(BUILD)/rom/0x03e30000.fv # Unknown (512 KB)
+FVS += $(BUILD)/rom/0x03e80000.fv # PeiCore (recovery) (512 KB)
+FVS += $(BUILD)/rom/0x03f00000.fv # Microcode in FIT (196 KB)
+FVS += $(BUILD)/rom/0x03f30000.fv # Unknown (512 KB)
+# FVS += $(BUILD)/rom/0x03f80000.fv # PeiCore (non-recovery?) (512 KB)
+FVS += $(BUILD)/512kb.fv # an empty FV to replace the unused PeiCore
+
+$(BUILD)/512kb.fv: dxe/hello.ffs
+	./bin/create-fv -s 0x80000 $< > $@
+$(BUILD)/2mb.fv: dxe/hello.ffs
+	./bin/create-fv -s 0x200000 $< > $@
 
 
 # Replace the DxeCore and SmmCore with our own
 $(BUILD)/dxe.vol: \
 	$(BUILD)/DxeCore.ffs \
 	$(BUILD)/PiSmmCore.ffs \
+	dxe/fvloader.ffs \
+	dxe/hello.ffs \
 	$(dxe-files) \
+
+dxe/fvloader.ffs dxe/hello.ffs: dxe.intermediate
+dxe.intermediate:
+	$(MAKE) -C dxe
 
 # Linux and initrd go into their own FV
 $(BUILD)/linux.vol: \

--- a/boards/s2600wf/Makefile.board
+++ b/boards/s2600wf/Makefile.board
@@ -31,8 +31,6 @@ dxe-files := $(shell awk  \
 	boards/$(BOARD)/image-files.txt \
 )
 
-$(dxe-files): extract.intermediate
-
 
 # The Intel firmware has lots of small pieces.
 # We replace the DXE recovery image and one of the other

--- a/boards/winterfell/Makefile.board
+++ b/boards/winterfell/Makefile.board
@@ -19,8 +19,6 @@ dxe-files := $(shell awk  \
 	boards/$(BOARD)/image-files.txt \
 )
 
-$(dixe-files): extract.intermediate
-
 
 # The Intel firmware has lots of small pieces.
 # We replace the DXE recovery image and one of the other
@@ -43,27 +41,22 @@ $(BUILD)/dxe.vol: \
 	$(BUILD)/Linux.ffs \
 	$(BUILD)/Initrd.ffs \
 
+#
+# Compact the NVRAM region.  this isn't required, but makes for cleaner images.
+#
 nvram1-size := 0x20000
 nvram2-size := 0x20000
 $(BUILD)/nvram1.vol: $(BUILD)/nvram1.ffs
 $(BUILD)/nvram2.vol: $(BUILD)/nvram2.ffs
 
-$(BUILD)/nvram1.ffs: $(BUILD)/rom/0x00800000/cef5b9a3-476d-497f-9fdc-e98143e0422c.ffs
+NVRAM_GUID = cef5b9a3-476d-497f-9fdc-e98143e0422c
+NVRAM1_FFS = $(BUILD)/rom/0x00800000/$(NVRAM_GUID).ffs
+NVRAM2_FFS = $(BUILD)/rom/0x00820000/$(NVRAM_GUID).ffs
+$(NVRAM1_FFS) $(NVRAM2_FFS): $(BUILD)/$(BOARD).txt
+	@true
+
+$(BUILD)/nvram1.ffs: $(NVRAM1_FFS)
 	./bin/nvram-compact < $< > $@
-$(BUILD)/nvram2.ffs: $(BUILD)/rom/0x00820000/cef5b9a3-476d-497f-9fdc-e98143e0422c.ffs
+$(BUILD)/nvram2.ffs: $(NVRAM2_FFS)
 	./bin/nvram-compact < $< > $@
 
-# I wish we could use our own builds of these, but
-# the AMI firmware modules do not play nice with us.
-NO = \
-	$(BUILD)/DxeCore.ffs \
-	$(BUILD)/ReportStatusCodeRouterRuntimeDxe.ffs \
-	$(BUILD)/StatusCodeHandlerRuntimeDxe.ffs \
-	$(BUILD)/RuntimeDxe.ffs \
-	$(BUILD)/PiSmmCore.ffs \
-	$(BUILD)/RuntimeDxe.ffs \
-	$(BUILD)/AcpiTableDxe.ffs \
-	$(BUILD)/AcpiPlatform.ffs \
-        $(BUILD)/PciBusDxe.ffs \
-        $(BUILD)/PciHostBridgeDxe.ffs \
-        $(BUILD)/PciSioSerialDxe.ffs \


### PR DESCRIPTION
This fixes #14 as well as bugs that @vejmarie reported trying to do a parallel Winterfell build due to FFS creation happening while `extract-firmware` was running.