### PR TITLE
Enable tighten me on OCP Winterfell

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,9 +83,11 @@ $(BUILD)/%.ffs: $(EDK2_OUTPUT_DIR)/%.efi
 $(BUILD)/%.ffs:
 	$(create-ffs)
 
+ROM_SIZE ?= `stat -c"%s" $(ROM)`
+
 $(BUILD)/%.rom:
 	cat > $@.tmp $^
-	@if [ `stat -c"%s" $@.tmp` -ne `stat -c"%s" $(ROM)` ]; then \
+	@if [ `stat -c"%s" $@.tmp` -ne $(ROM_SIZE) ]; then \
 		printf >&2 "%s: Wrong output size 0x%x != expected 0x%x\n" \
 			$@ `stat -c'%s' $@.tmp` `stat -c'%s' $(ROM)` ; \
 		exit 1; \

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ $(shell \
 	mkdir -p $(BUILD) ; \
 )
 
+realinitrd := $(INITRD)
 # Bring in the board specific things
 include boards/$(BOARD)/Makefile.board
 
@@ -70,7 +71,7 @@ edk2/.git:
 	git clone --depth 1 --branch UDK2018 https://github.com/linuxboot/edk2
 
 $(BUILD)/Linux.ffs: $(KERNEL)
-$(BUILD)/Initrd.ffs: $(INITRD)
+$(BUILD)/Initrd.ffs: $(realinitrd)
 
 ifdef CUSTOM
 $(BUILD)/User.ffs: $(CUSTOM) FORCE

--- a/Makefile
+++ b/Makefile
@@ -165,7 +165,7 @@ $(BUILD)/dxe/volume_config.h: boards/$(BOARD)/volume_config.h
 ifndef USE_UTK
 $(BUILD)/linuxboot.rom: $(FVS)
 else
-$(BUILD)/linuxboot.rom: bin/utk $(DXE_FFS)
+$(BUILD)/linuxboot.rom: bin/utk $(DXE_FFS) $(UTK_EXTRA_DEPS)
 	$< \
 		$(ROM) \
 		remove_dxes_except boards/$(BOARD)/image-files.txt \

--- a/Makefile
+++ b/Makefile
@@ -147,6 +147,21 @@ $(dxe-files): $(BUILD)/$(BOARD).txt
 dxe/%.ffs:
 	$(MAKE) -C dxe $(notdir $@)
 
+# Alternatively DXE modules can be build in $(BUILD)/dxe
+$(BUILD)/dxe/%.ffs: $(BUILD)/dxe/Makefile
+	$(MAKE) -C $(BUILD)/dxe $(notdir $@)
+
+
+$(BUILD)/dxe/Makefile: $(BUILD)/dxe/volume_config.h
+	@mkdir -p $(dir $@)
+	@echo "SRCDIR := $(realpath dxe)/" > $@
+	@echo "include $$""(SRCDIR)Makefile" >> $@
+	@echo "CFLAGS += -I . -DVOLUME_CONFIG_INCLUDE" >> $@
+
+$(BUILD)/dxe/volume_config.h: boards/$(BOARD)/volume_config.h
+	@mkdir -p $(dir $@)
+	@cp $^ $@
+
 ifndef USE_UTK
 $(BUILD)/linuxboot.rom: $(FVS)
 else

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,7 @@ config:
 	echo 'KERNEL ?= $(KERNEL)' >> .config
 	echo 'INITRD ?= $(INITRD)' >> .config
 	echo 'ROM ?= $(ROM)' >> .config
+	echo 'CUSTOM ?= $(CUSTOM)' >> .config
 
 
 # edk2 outputs will be in this deeply nested directory
@@ -71,6 +72,13 @@ edk2/.git:
 $(BUILD)/Linux.ffs: $(KERNEL)
 $(BUILD)/Initrd.ffs: $(INITRD)
 
+ifdef CUSTOM
+$(BUILD)/User.ffs: $(CUSTOM) FORCE
+$(CUSTOM):
+$(BUILD)/user.vol: $(BUILD)/User.ffs
+else
+$(BUILD)/user.vol: FORCE
+endif
 
 $(BUILD)/%.ffs: $(BUILD)/%.vol
 	./bin/create-ffs \

--- a/Makefile
+++ b/Makefile
@@ -91,13 +91,13 @@ $(BUILD)/%.ffs: $(EDK2_OUTPUT_DIR)/%.efi
 $(BUILD)/%.ffs:
 	$(create-ffs)
 
-ROM_SIZE ?= `stat -c"%s" $(ROM)`
+ROM_SIZE ?= `stat -Lc"%s" $(ROM)`
 
 $(BUILD)/%.rom:
 	cat > $@.tmp $^
 	@if [ `stat -c"%s" $@.tmp` -ne $(ROM_SIZE) ]; then \
 		printf >&2 "%s: Wrong output size 0x%x != expected 0x%x\n" \
-			$@ `stat -c'%s' $@.tmp` `stat -c'%s' $(ROM)` ; \
+			$@ `stat -c'%s' $@.tmp` `stat -Lc'%s' $(ROM)` ; \
 		exit 1; \
 	fi
 	mv $@.tmp $@

--- a/Makefile.uefi
+++ b/Makefile.uefi
@@ -27,6 +27,9 @@ Linux-type := APPLICATION
 Initrd-type := FREEFORM
 Initrd-guid := 74696e69-6472-632e-7069-6f2f62696f73
 
+User-type := FREEFORM
+User-guid := 74696e69-6472-632e-7069-6f2f75736572
+
 DxeCore-type := DXE_CORE
 DxeCore-guid := D6A2CB7F-6A18-4E2F-B43B-9920A733700A
 

--- a/Makefile.uefi
+++ b/Makefile.uefi
@@ -27,6 +27,9 @@ Linux-type := APPLICATION
 Initrd-type := FREEFORM
 Initrd-guid := 74696e69-6472-632e-7069-6f2f62696f73
 
+Initrdpart-type := FREEFORM
+Initrdpart-guid := 74696e69-6472-632e-7069-6f2f70617274
+
 User-type := FREEFORM
 User-guid := 74696e69-6472-632e-7069-6f2f75736572
 

--- a/boards/qemu/Makefile.board
+++ b/boards/qemu/Makefile.board
@@ -15,7 +15,8 @@
 #
 
 dxe-size	:= 0xA00000
-merged-size	:= 0x748000
+merged-size	:= 0x700000
+user-size	:= 0x048000
 
 fv-path := $(BUILD)/rom/0x00084000/9e21fd93-9c72-4c15-8c4b-e77f1db2d792
 dxe-path := $(fv-path)/1
@@ -33,6 +34,7 @@ $(fv-path)/0.fv: $(BUILD)/$(BOARD).txt
 
 FVS := \
 	$(BUILD)/rom/0x00000000.fv \
+	$(BUILD)/user.vol \
 	$(BUILD)/merged.vol \
 	$(BUILD)/rom/0x007cc000.fv \
 

--- a/boards/winterfell/Makefile.board
+++ b/boards/winterfell/Makefile.board
@@ -22,6 +22,9 @@ dxe-files := $(shell awk  \
 
 extra-size	:= 0x4E0000
 
+# extra-size - 0x108 (need to be word aligned) decimal for dd
+INITRD_SPLIT	:= 5111544
+
 # The Intel firmware has lots of small pieces.
 # We replace the DXE recovery image and one of the other
 # images with the LinuxBoot one.  Potentially we
@@ -52,6 +55,22 @@ $(BUILD)/Initrd.ffs \
 
 $(BUILD)/extra.vol: $(EXTRA_FFS)
 
+#
+ifdef INITRD_SPLIT
+realinitrd := $(INITRD).1
+partinitrd := $(INITRD).2
+
+$(realinitrd): $(INITRD)
+	dd if=$^ of=$@ bs=1 count=$(INITRD_SPLIT)
+
+$(partinitrd): $(INITRD)
+	dd if=$^ of=$@ bs=1 skip=$(INITRD_SPLIT)
+
+$(BUILD)/Initrdpart.ffs: $(partinitrd)
+
+$(BUILD)/dxe.vol: $(BUILD)/Initrdpart.ffs
+
+endif
 #
 # Compact the NVRAM region.  this isn't required, but makes for cleaner images.
 #

--- a/boards/winterfell/Makefile.board
+++ b/boards/winterfell/Makefile.board
@@ -43,7 +43,7 @@ $(BUILD)/rom/0x00f00000.fv \
 # Replace the DxeCore and SmmCore with our own
 # and add in the Linux kernel / initrd
 DXE_FFS := \
-./dxe/linuxboot.ffs \
+$(BUILD)/dxe/linuxboot.ffs \
 $(BUILD)/Linux.ffs \
 
 $(BUILD)/dxe.vol: \

--- a/boards/winterfell/Makefile.board
+++ b/boards/winterfell/Makefile.board
@@ -68,7 +68,8 @@ $(partinitrd): $(INITRD)
 
 $(BUILD)/Initrdpart.ffs: $(partinitrd)
 
-$(BUILD)/dxe.vol: $(BUILD)/Initrdpart.ffs
+DXE_FFS += \
+$(BUILD)/Initrdpart.ffs
 
 endif
 #
@@ -101,5 +102,12 @@ $(BUILD)/0x00010000-cut.bin: $(BUILD)/rom/0x00010000.bin
 #
 
 nvram-nvar-keep := boards/$(BOARD)/nvar-keep.txt
-
 UTK_EXTRA_OPS := invalidate_nvar_except $(nvram-nvar-keep) nvram-compact
+
+# UTK create fv
+EXTRA_FV_GUID := e10864aa-9088-512e-970f-0a454d0aeb6a
+
+UTK_EXTRA_DEPS := $(EXTRA_FFS)
+UTK_EXTRA_OPS += tighten_me create-fv 0x320000 $(extra-size) $(EXTRA_FV_GUID) \
+		 $(foreach ffs,$(EXTRA_FFS), insert_end $(EXTRA_FV_GUID) $(ffs))
+

--- a/boards/winterfell/Makefile.board
+++ b/boards/winterfell/Makefile.board
@@ -20,13 +20,16 @@ dxe-files := $(shell awk  \
 )
 
 
+extra-size	:= 0x4E0000
+
 # The Intel firmware has lots of small pieces.
 # We replace the DXE recovery image and one of the other
 # images with the LinuxBoot one.  Potentially we
 # can clean up more space.
 FVS := \
 $(BUILD)/rom/0x00000000.ifd \
-$(BUILD)/rom/0x00010000.bin \
+$(BUILD)/0x00010000-cut.bin \
+$(BUILD)/extra.vol \
 $(BUILD)/nvram1.vol \
 $(BUILD)/nvram2.vol \
 $(BUILD)/rom/0x00840000.bin \
@@ -39,11 +42,15 @@ $(BUILD)/rom/0x00f00000.fv \
 DXE_FFS := \
 ./dxe/linuxboot.ffs \
 $(BUILD)/Linux.ffs \
-$(BUILD)/Initrd.ffs \
 
 $(BUILD)/dxe.vol: \
 	$(dxe-files) \
 	$(DXE_FFS) \
+
+EXTRA_FFS := \
+$(BUILD)/Initrd.ffs \
+
+$(BUILD)/extra.vol: $(EXTRA_FFS)
 
 #
 # Compact the NVRAM region.  this isn't required, but makes for cleaner images.
@@ -63,6 +70,12 @@ $(BUILD)/nvram1.ffs: $(NVRAM1_FFS)
 	./bin/nvram-compact < $< > $@
 $(BUILD)/nvram2.ffs: $(NVRAM2_FFS)
 	./bin/nvram-compact < $< > $@
+
+# Make sure the firmware is extracted before
+$(BUILD)/rom/0x00010000.bin: $(BUILD)/$(BOARD).txt
+
+$(BUILD)/0x00010000-cut.bin: $(BUILD)/rom/0x00010000.bin
+	dd if=$< of=$@ bs=4096 count=784
 
 #
 # UTK Compact the NVRAM region

--- a/boards/winterfell/volume_config.h
+++ b/boards/winterfell/volume_config.h
@@ -1,0 +1,7 @@
+// User
+// #define VOLUME_ADDRESS 0xFF840000
+// #define VOLUME_LENGTH  0x20000
+// Extra
+#define VOLUME2_ADDRESS 0xFF320000
+#define VOLUME2_LENGTH  0x4E0000
+

--- a/dxe/Makefile
+++ b/dxe/Makefile
@@ -23,7 +23,7 @@ FORCE:
 %.exe:
 	$(CROSS)ld \
 		$(LDFLAGS) \
-		-T elf_x86_64_efi.lds \
+		-T $(SRCDIR)elf_x86_64_efi.lds \
 		-o $@ \
 		$^
 
@@ -39,7 +39,7 @@ FORCE:
 	/usr/bin/printf '\x2E\x00' | dd of=$@ conv=notrunc bs=1 seek=150 status=none
 
 %.ffs: %.efi
-	../bin/create-ffs \
+	$(SRCDIR)../bin/create-ffs \
 		-o $@ \
 		--type DRIVER \
 		--version 1.0 \
@@ -59,8 +59,8 @@ CFLAGS += \
 	-O3 \
 	-W \
 	-Wall \
-	-I . \
-	-I efi/x86_64 \
+	-I $(SRCDIR). \
+	-I $(SRCDIR)efi/x86_64 \
 	-MMD \
 	-MF .$(notdir $@).d \
 
@@ -76,5 +76,7 @@ NO_LFLAGS += \
 	-L $(LIB) \
 	$(EFI_CRT_OBJS)  \
 
+%.o: $(SRCDIR)%.c
+	$(COMPILE.c) $(OUTPUT_OPTION) $<
 
 -include .*.d

--- a/dxe/efi/pci22.h
+++ b/dxe/efi/pci22.h
@@ -1,0 +1,194 @@
+#ifndef _PCI22_H
+#define _PCI22_H
+
+/*++
+
+Copyright (c) 1999  Intel Corporation
+
+Module Name:
+
+    pci22.h
+    
+Abstract:      
+    Support for PCI 2.2 standard.
+
+
+
+
+Revision History
+
+--*/
+
+#ifdef SOFT_SDV
+#define PCI_MAX_BUS     1
+#else
+#define PCI_MAX_BUS     255
+#endif
+
+#define PCI_MAX_DEVICE  31
+#define PCI_MAX_FUNC    7
+
+//
+// Command
+//
+#define PCI_VGA_PALETTE_SNOOP_DISABLED   0x20
+
+#pragma pack(1)
+typedef struct {
+    UINT16      VendorId;
+    UINT16      DeviceId;
+    UINT16      Command;
+    UINT16      Status;
+    UINT8       RevisionID;
+    UINT8       ClassCode[3];
+    UINT8       CacheLineSize;
+    UINT8       LaytencyTimer;
+    UINT8       HeaderType;
+    UINT8       BIST;
+} PCI_DEVICE_INDEPENDENT_REGION;
+
+typedef struct {
+    UINT32      Bar[6];
+    UINT32      CISPtr;
+    UINT16      SubsystemVendorID;
+    UINT16      SubsystemID;
+    UINT32      ExpansionRomBar;
+    UINT32      Reserved[2];
+    UINT8       InterruptLine;
+    UINT8       InterruptPin;
+    UINT8       MinGnt;
+    UINT8       MaxLat;     
+} PCI_DEVICE_HEADER_TYPE_REGION;
+
+typedef struct {
+    PCI_DEVICE_INDEPENDENT_REGION   Hdr;
+    PCI_DEVICE_HEADER_TYPE_REGION   Device;
+} PCI_TYPE00;
+
+typedef struct {              
+    UINT32      Bar[2];
+    UINT8       PrimaryBus;
+    UINT8       SecondaryBus;
+    UINT8       SubordinateBus;
+    UINT8       SecondaryLatencyTimer;
+    UINT8       IoBase;
+    UINT8       IoLimit;
+    UINT16      SecondaryStatus;
+    UINT16      MemoryBase;
+    UINT16      MemoryLimit;
+    UINT16      PrefetchableMemoryBase;
+    UINT16      PrefetchableMemoryLimit;
+    UINT32      PrefetchableBaseUpper32;
+    UINT32      PrefetchableLimitUpper32;
+    UINT16      IoBaseUpper16;
+    UINT16      IoLimitUpper16;
+    UINT32      Reserved;
+    UINT32      ExpansionRomBAR;
+    UINT8       InterruptLine;
+    UINT8       InterruptPin;
+    UINT16      BridgeControl;
+} PCI_BRIDGE_CONTROL_REGISTER;
+
+#define PCI_CLASS_DISPLAY_CTRL          0x03
+#define PCI_CLASS_VGA                   0x00
+
+#define PCI_CLASS_BRIDGE                0x06
+#define PCI_CLASS_ISA                   0x01
+#define PCI_CLASS_ISA_POSITIVE_DECODE   0x80
+
+#define PCI_CLASS_NETWORK               0x02 
+#define PCI_CLASS_ETHERNET              0x00
+        
+#define HEADER_TYPE_DEVICE              0x00
+#define HEADER_TYPE_PCI_TO_PCI_BRIDGE   0x01
+#define HEADER_TYPE_MULTI_FUNCTION      0x80
+#define HEADER_LAYOUT_CODE              0x7f
+
+#define IS_PCI_BRIDGE(_p) ((((_p)->Hdr.HeaderType) & HEADER_LAYOUT_CODE) == HEADER_TYPE_PCI_TO_PCI_BRIDGE)        
+#define IS_PCI_MULTI_FUNC(_p)   (((_p)->Hdr.HeaderType) & HEADER_TYPE_MULTI_FUNCTION)         
+
+typedef struct {
+    PCI_DEVICE_INDEPENDENT_REGION   Hdr;
+    PCI_BRIDGE_CONTROL_REGISTER     Bridge;
+} PCI_TYPE01;
+
+typedef struct {
+    UINT8   Register;
+    UINT8   Function;
+    UINT8   Device;
+    UINT8   Bus;
+    UINT8   Reserved[4];
+} DEFIO_PCI_ADDR;
+
+typedef struct {
+    UINT32  Reg     : 8;
+    UINT32  Func    : 3;
+    UINT32  Dev     : 5;
+    UINT32  Bus     : 8;
+    UINT32  Reserved: 7;
+    UINT32  Enable  : 1;
+} PCI_CONFIG_ACCESS_CF8;
+
+#pragma pack()
+
+#if 0
+#define EFI_ROOT_BRIDGE_LIST    'eprb'
+typedef struct {
+    UINTN           Signature;
+
+    UINT16          BridgeNumber;
+    UINT16          PrimaryBus;
+    UINT16          SubordinateBus;
+
+    EFI_DEVICE_PATH *DevicePath;
+
+    LIST_ENTRY      Link;
+} PCI_ROOT_BRIDGE_ENTRY;
+#endif
+
+#define PCI_EXPANSION_ROM_HEADER_SIGNATURE        0xaa55
+#define EFI_PCI_EXPANSION_ROM_HEADER_EFISIGNATURE 0x0EF1
+#define PCI_DATA_STRUCTURE_SIGNATURE              EFI_SIGNATURE_32('P','C','I','R')
+
+#pragma pack(1)
+typedef struct {
+    UINT16          Signature;              // 0xaa55
+    UINT8           Reserved[0x16];
+    UINT16          PcirOffset;
+} PCI_EXPANSION_ROM_HEADER;
+
+
+typedef struct {
+    UINT16          Signature;              // 0xaa55
+    UINT16          InitializationSize;
+    UINT16          EfiSignature;           // 0x0EF1
+    UINT16          EfiSubsystem;
+    UINT16          EfiMachineType;
+    UINT8           Reserved[0x0A];
+    UINT16          EfiImageHeaderOffset;
+    UINT16          PcirOffset;
+} EFI_PCI_EXPANSION_ROM_HEADER;
+
+typedef struct {
+    UINT32          Signature;              // "PCIR" 
+    UINT16          VendorId;
+    UINT16          DeviceId;
+    UINT16          Reserved0;
+    UINT16          Length;
+    UINT8           Revision;
+    UINT8           ClassCode[3];
+    UINT16          ImageLength;
+    UINT16          CodeRevision;
+    UINT8           CodeType;
+    UINT8           Indicator;
+    UINT16          Reserved1;
+} PCI_DATA_STRUCTURE;
+#pragma pack()
+
+#endif
+    
+
+
+
+
+    

--- a/dxe/efifv.h
+++ b/dxe/efifv.h
@@ -88,4 +88,13 @@ read_ffs(
 	EFI_SECTION_TYPE section_type
 );
 
+int
+append_read_ffs(
+	EFI_BOOT_SERVICES * gBS,
+	EFI_GUID * guid,
+	void ** buffer,
+	UINTN * size,
+	EFI_SECTION_TYPE section_type
+);
+
 #endif

--- a/dxe/linuxboot.c
+++ b/dxe/linuxboot.c
@@ -267,14 +267,17 @@ lpc_update_flash_access(void)
 	serial_hex(reg16, 4);
 
 
-	reg16 = 0xFFCF;
-	status = LpcPciIo->Pci.Write(LpcPciIo, EfiPciIoWidthUint16, BIOS_DEC_EN1, 1, &reg16);
-	if (EFI_ERROR (status)) {
-		serial_string("status=");
-		serial_hex(status, 8);
-		return;
-	}
 	status = LpcPciIo->Pci.Read(LpcPciIo, EfiPciIoWidthUint16, BIOS_DEC_EN1, 1, &reg16);
+	if (reg16 != 0xFFCF) {
+		reg16 = 0xFFCF;
+		status = LpcPciIo->Pci.Write(LpcPciIo, EfiPciIoWidthUint16, BIOS_DEC_EN1, 1, &reg16);
+		if (EFI_ERROR (status)) {
+			serial_string("status=");
+			serial_hex(status, 8);
+			return;
+		}
+		status = LpcPciIo->Pci.Read(LpcPciIo, EfiPciIoWidthUint16, BIOS_DEC_EN1, 1, &reg16);
+	}
 	serial_string("BIOS_DEC_EN1=");
 	serial_hex(reg16, 4);
 }

--- a/dxe/linuxboot.c
+++ b/dxe/linuxboot.c
@@ -342,6 +342,7 @@ linuxboot_start()
 	EFI_STATUS status;
 	EFI_GUID bzimage_guid = { 0xDECAFBAD, 0x6548, 0x6461, { 0x73, 0x2d, 0x2f, 0x2d, 0x4e, 0x45, 0x52, 0x46 }};
 	EFI_GUID initrd_guid = { 0x74696e69, 0x6472, 0x632e, { 0x70, 0x69, 0x6f, 0x2f, 0x62, 0x69, 0x6f, 0x73 }};
+	EFI_GUID initrdpart_guid = { 0x74696e69, 0x6472, 0x632e, { 0x70, 0x69, 0x6f, 0x2f, 0x70, 0x61, 0x72, 0x74 }};
 
 	void * bzimage_buffer = NULL;
 	UINTN bzimage_length = 0;
@@ -389,6 +390,12 @@ linuxboot_start()
 		loaded_image->LoadOptions = cmdline;
 		loaded_image->LoadOptionsSize = sizeof(cmdline);
 
+		serial_string("LinuxBoot: Looking for a second initrd part\r\n");
+		append_read_ffs(gBS, &initrdpart_guid, &initrd_buffer, &initrd_length, EFI_SECTION_RAW);
+		serial_string("LinuxBoot: initrd buffer=");
+		serial_hex((unsigned long) initrd_buffer, 16);
+		serial_string("LinuxBoot: initrd length=");
+		serial_hex(initrd_length, 8);
 		uintptr_t hdr = (uintptr_t) loaded_image->ImageBase;
 		*(uint32_t*)(hdr + 0x218) = (uint32_t)(uintptr_t) initrd_buffer;
 		*(uint32_t*)(hdr + 0x21c) = (uint32_t)(uintptr_t) initrd_length;

--- a/lib/EFI.pm
+++ b/lib/EFI.pm
@@ -269,11 +269,12 @@ sub ffs
 	my $type_byte = $file_types{$file_type}
 		or die "$file_type: Unknown file type\n";
 
-	my $attr = 0x28; # == aligned?
-	my $state = 0x07;
+	#my $attr = 0x28; # == aligned?
+	my $attr = 0x40; # == aligned?
+	my $state = 0xF8;
 	if ($file_type eq 'FFS_PAD')
 	{
-		$attr = 0x00;
+		$attr = 0x40;
 		$state = 0xF8;
 	}
 
@@ -297,7 +298,14 @@ sub ffs
 		$sum -= ord(substr($ffs, $i, 1));
 	}
 
-	substr($ffs, 0x10, 2) = chr($sum & 0xFF) . chr(0xAA);
+	# fixup the data checksum
+	my $data_sum = 0x00;
+	for my $i (0..length($data))
+	{
+		$data_sum -= ord(substr($data, $i, 1));
+	}
+
+	substr($ffs, 0x10, 2) = chr($sum & 0xFF) . chr($data_sum & 0xFF);
 
 	# Add the rest of the data
 	return $ffs . $data;


### PR DESCRIPTION
I enable tighten_me on UTK, the idea is that ME doesn't use its full partition so we can recover space from it.
But that space will not be contiguous with the rest of the FVs, so a new FV is created in the free spot.
I also added a feature to split the initrd file in two parts and use the dxe loader code to concatenate back the parts in memory.

This basically solves the issue with golang building bigger binaries. And ease the porting of new platforms as less dxe need to be blindly removed to make room in the flash.