### PR TITLE
Fix UTK builds and QEMU board's ASSERT error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,7 @@ clean
 *.bin
 *.bad
 blobs/*/volume*
+bin/create-ffs.utk
 bin/utk
 edk2
 bzImage

--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,7 @@ clean
 *.bin
 *.bad
 blobs/*/volume*
+bin/utk
 edk2
 bzImage
 boards/*/volume-*

--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ $(BUILD)/%.vol:
 		$(filter-out $(BUILD)/$(BOARD).txt,$^)
 
 create-ffs = \
-	./bin/create-ffs \
+	./bin/create-ffs$(if $(USE_UTK),.utk,) \
 		-o $@ \
 		--name $(basename $(notdir $@)) \
 		--version 1.0 \
@@ -146,7 +146,7 @@ DXE_FFS += $(BUILD)/Initrd.ffs
 # The Perl way of building replaces DxeCore with a custom version but
 # UTK needs the original DxeCore, so uncomment DxeCore in image-files.txt
 # on-the-fly before passing it to UTK.
-$(BUILD)/linuxboot.rom: bin/utk $(DXE_FFS)
+$(BUILD)/linuxboot.rom: bin/utk bin/create-ffs.utk $(DXE_FFS)
 	$< \
 		$(ROM) \
 		remove_dxes_except \
@@ -160,4 +160,4 @@ endif
 clean:
 	$(MAKE) -C dxe clean
 	$(RM) $(BUILD)/{*.ffs,*.rom,*.vol,*.tmp}
-	$(RM) ./bin/utk
+	$(RM) ./bin/utk ./bin/create-ffs.utk

--- a/Makefile
+++ b/Makefile
@@ -152,5 +152,6 @@ $(BUILD)/linuxboot.rom: bin/utk $(DXE_FFS)
 endif
 
 clean:
+	$(MAKE) -C dxe clean
 	$(RM) $(BUILD)/{*.ffs,*.rom,*.vol,*.tmp}
 	$(RM) ./bin/utk

--- a/Makefile
+++ b/Makefile
@@ -142,10 +142,16 @@ else
 DXE_FFS += dxe/linuxboot.ffs
 DXE_FFS += $(BUILD)/Linux.ffs
 DXE_FFS += $(BUILD)/Initrd.ffs
+
+# The Perl way of building replaces DxeCore with a custom version but
+# UTK needs the original DxeCore, so uncomment DxeCore in image-files.txt
+# on-the-fly before passing it to UTK.
 $(BUILD)/linuxboot.rom: bin/utk $(DXE_FFS)
 	$< \
 		$(ROM) \
-		remove_dxes_except boards/$(BOARD)/image-files.txt \
+		remove_dxes_except \
+		  <(sed 's|^#[[:space:]]\+\(d6a2cb7f-6a18-4e2f-b43b-9920a733700a\)[[:space:]]\+\(DxeCore\)|\1 \2|' \
+		    boards/$(BOARD)/image-files.txt) \
 		$(foreach ffs,$(DXE_FFS), insert_dxe $(ffs)) \
 		$(UTK_EXTRA_OPS) \
 		save $@

--- a/Makefile
+++ b/Makefile
@@ -139,6 +139,9 @@ dxe/%.ffs:
 ifndef USE_UTK
 $(BUILD)/linuxboot.rom: $(FVS)
 else
+DXE_FFS += dxe/linuxboot.ffs
+DXE_FFS += $(BUILD)/Linux.ffs
+DXE_FFS += $(BUILD)/Initrd.ffs
 $(BUILD)/linuxboot.rom: bin/utk $(DXE_FFS)
 	$< \
 		$(ROM) \

--- a/Makefile.utk
+++ b/Makefile.utk
@@ -26,3 +26,6 @@ bin/utk:
 	go get github.com/linuxboot/fiano/cmds/utk
 	cp $(GOPATH)/bin/utk $@
 
+bin/create-ffs.utk:
+	go get github.com/linuxboot/fiano/cmds/create-ffs
+	cp $(GOPATH)/bin/create-ffs $@

--- a/boards/qemu/image-files.txt
+++ b/boards/qemu/image-files.txt
@@ -1,5 +1,5 @@
 fc510ee7-ffdc-11d4-bd41-0080c73c8881 DXE Apriori
-d6a2cb7f-6a18-4e2f-b43b-9920a733700a DxeCore
+# d6a2cb7f-6a18-4e2f-b43b-9920a733700a DxeCore
 d93ce3d8-a7eb-4730-8c8e-cc466a9ecc3c ReportStatusCodeRouterRuntimeDxe
 6c2004ef-4e0e-4be4-b14c-340eb4aa5891 StatusCodeHandlerRuntimeDxe
 80cf7257-87ab-47f9-a3fe-d50b76d89541 PcdDxe

--- a/boards/qemu/image-files.txt
+++ b/boards/qemu/image-files.txt
@@ -1,15 +1,15 @@
 fc510ee7-ffdc-11d4-bd41-0080c73c8881 DXE Apriori
-# d6a2cb7f-6a18-4e2f-b43b-9920a733700a DxeCore
+d6a2cb7f-6a18-4e2f-b43b-9920a733700a DxeCore
 d93ce3d8-a7eb-4730-8c8e-cc466a9ecc3c ReportStatusCodeRouterRuntimeDxe
 6c2004ef-4e0e-4be4-b14c-340eb4aa5891 StatusCodeHandlerRuntimeDxe
 80cf7257-87ab-47f9-a3fe-d50b76d89541 PcdDxe
 b601f8c4-43b7-4784-95b1-f4226cb40cee RuntimeDxe
 f80697e9-7fd6-4665-8646-88e33ef71dfc SecurityStubDxe
 13ac6dd0-73d0-11d4-b06b-00aa00bd6de7 EbcDxe
-79ca4208-bba1-4a9a-8456-e1e66a81484e Legacy8259
+245CB4DA-8E15-4A1B-87E3-9878FFA07520 Legacy8259
 a19b1fe7-c1bc-49f8-875f-54a5d542443f CpuIo2Dxe
 1a1e4886-9517-440e-9fde-3be44cee2136 CpuDxe
-f2765dec-6b41-11d5-8e71-00902707b35e Timer
+C190FE35-44AA-41A1-8AEA-4947BC60E09D Timer
 f6697ac4-a776-4ee1-b643-1feff2b615bb IncompatiblePciDeviceSupportDxe
 11a6edf6-a9be-426d-a6cc-b22fe51d9224 PciHotPlugInitDxe
 128fb770-5e79-4176-9e51-9bb268a17dd1 PciHostBridgeDxe
@@ -29,6 +29,7 @@ f9d88642-0737-49bc-81b5-6889cd57d9ea SmbiosDxe
 49970331-e3fa-4637-9abc-3b7868676970 AcpiPlatform
 7e374e25-8e01-4fee-87f2-390c23c606cd ACPI data
 bdce85bb-fbaa-4f4e-9264-501a2c249581 S3SaveStateDxe
+7C04A583-9E3E-4F1C-AD65-E05268D0B4D1 Shell
 d9dcc5df-4007-435e-9098-8970935504b2 PlatformDxe
 2ec9da37-ee35-4de9-86c5-6d9a81dc38a7 AmdSevDxe
 8657015b-ea43-440d-949a-af3be365c0fc IoMmuDxe

--- a/dxe/Makefile
+++ b/dxe/Makefile
@@ -39,7 +39,7 @@ FORCE:
 	/usr/bin/printf '\x2E\x00' | dd of=$@ conv=notrunc bs=1 seek=150 status=none
 
 %.ffs: %.efi
-	../bin/create-ffs \
+	../bin/create-ffs$(if $(USE_UTK),.utk,) \
 		-o $@ \
 		--type DRIVER \
 		--version 1.0 \


### PR DESCRIPTION
Building with UTK doesn't actually add `linuxboot.ffs`, `Linux.ffs`, or `Initrd.ffs` to the DXE volume after removing the DXEs and so, for example, running the QEMU board will fail with `X64 Exception Type - 06(#UD - Invalid Opcode)`.

Add these to the DXE volume when building with UTK and update the GUIDs in the QEMU board's image-files.txt to address #46.