### PR TITLE
tianocore/ovmf: Change golang version to 1.17

### DIFF
--- a/mainboards/tianocore/ovmf/Dockerfile
+++ b/mainboards/tianocore/ovmf/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16.4-buster
+FROM golang:1.17
 
 LABEL description="Testing environment for Linuxboot in OVMF"
 
@@ -21,7 +21,7 @@ RUN apt install -y \
 
 # Get the correct version of UTK
 RUN git clone https://github.com/linuxboot/fiano /go/src/github.com/linuxboot/fiano
-RUN cd /go/src/github.com/linuxboot/fiano/cmds/utk && git checkout v5.0.0 && GO111MODULE=off go install
+RUN cd /go/src/github.com/linuxboot/fiano/cmds/utk && GO111MODULE=off go get
 
 # Working directory for mounting git repo in
 RUN mkdir /linuxboot-ovmf


### PR DESCRIPTION
Change golang version to 1.17 to match the
go.mod's version which in the finao repo