### PR TITLE
fix(intel/hw): A typo: log.Fatal -> log.Fatalf

### DIFF
--- a/mainboards/intel/hw/insert.go
+++ b/mainboards/intel/hw/insert.go
@@ -42,10 +42,10 @@ func main() {
 		log.Fatalf("Size of %q (%d) > allowed size (%d)", initramfs, len(ramfs), sz)
 	}
 	if off > uint64(len(img)) {
-		log.Fatal("Off (%d) is > image size (%d)", off, len(img))
+		log.Fatalf("Off (%d) is > image size (%d)", off, len(img))
 	}
 	if off+sz > uint64(len(img)) {
-		log.Fatal("Off (%d) is > image size (%d)", off, len(img))
+		log.Fatalf("Off (%d) is > image size (%d)", off, len(img))
 	}
 
 	copy(img[off:], ramfs[:])


### PR DESCRIPTION
# Before

```
[xaionaro@void linuxboot]$ go test ./...
# github.com/linuxboot/linuxboot/mainboards/intel/hw
mainboards/intel/hw/insert.go:45:3: log.Fatal call has possible Printf formatting directive %d
mainboards/intel/hw/insert.go:48:3: log.Fatal call has possible Printf formatting directive %d
?   	github.com/linuxboot/linuxboot/mainboards/aeeon/up	[no test files]
FAIL	github.com/linuxboot/linuxboot/mainboards/intel/hw [build failed]
?   	github.com/linuxboot/linuxboot/mainboards/intel/hw/src/uinit	[no test files]
FAIL
```

# After

```
[xaionaro@void linuxboot]$ go test ./...
?   	github.com/linuxboot/linuxboot/mainboards/aeeon/up	[no test files]
?   	github.com/linuxboot/linuxboot/mainboards/intel/hw	[no test files]
?   	github.com/linuxboot/linuxboot/mainboards/intel/hw/src/uinit	[no test files]
```