### PR TITLE
CI: upgrade to checkout v4, upload-artifact 4, setup-go v5, Go 1.21

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,6 @@ jobs:
     env:
       # Setup $GOPATH
       GOPATH: ${{ github.workspace }}/go
-      # Turn off modules because they are broken.
-      GO111MODULE: off
 
     # Run the build for each one of these configurations in parallel.
     strategy:
@@ -69,12 +67,12 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can
       # access it.
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       # We need this newer version of Go.
       - name: Go version
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
-          go-version: '^1.17.6'
+          go-version: '1.21'
       - name: Install dependent packages
         run: |
           set -ex
@@ -90,13 +88,14 @@ jobs:
       - name: Make ${{ matrix.mainboard }} kernel
         run: |
           set -ex
+          go version
           cd mainboards
           PATH=$GOPATH/bin:/usr/local/go/bin:$PATH
           cd $(echo ${{ matrix.mainboard }} | tr '-' '/')
           make fetch
           make flashkernel
       - name: Upload Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.mainboard }}
           path: |

--- a/mainboards/aeeon/up/Makefile
+++ b/mainboards/aeeon/up/Makefile
@@ -1,98 +1,16 @@
+INITRAMFS:=initramfs.linux_amd64.cpio
+
 default: build
 
 build:
-	echo fetch, uroot, flashkernel, or image.bin
+	echo Run 'make fetch' first, which prepares the mainline build environment.
+	echo Obtain the ROM image; download from the Internet or read from flash.
+	echo Then make other targets, starting with a u-root flavor, finally Linux.
+	echo When the new image is built, write it to flash.
 
-image.bin:  
-	utk \
-		  -xzPath  /usr/bin/xz \
-		ROM.bin \
-		remove Nb.* \
-		remove IntelIsh.* \
-	        remove Ip.*  \
-                remove Tcp.*  \
-                remove Usb.*  \
-                remove Udp.*  \
-                remove Dhcp.*  \
-                remove .np.*  \
-                remove .tftp.*  \
-                remove Http.* \
-                remove .*Dns.* \
-                remove Arp.* \
-                remove .*NetworkStackSetupScreen.*  \
-                remove Iscsi.* \
-                remove Scsi.* \
-                remove Fat.* \
-                remove Ahci.* \
-                remove Partition.* \
-                remove Sata.* \
-                remove Disk.* \
-                remove Whea.* \
-                remove .*Pxe.* \
-                remove Ata.* \
-		remove AmiSeri.* \
-		remove IntelGop.* \
-		remove Logo.* \
-		remove Mouse.* \
-		remove .*Keyboard.* \
-		remove FlashDriver \
-		remove HiiDataBase \
-		remove EbcDxe \
-		remove AMITSE \
-		remove AMITSE.* \
-		remove Mmc.* \
-		remove Tcg.* \
-		remove Ish.* \
-		remove Setup \
-	save image.bin
-	utk image.bin table | guid2english | grep Free
-	echo \
-		remove AmiTc.* \
-	echo need 0x16b4a0
+# Prepare
 
-flashkernel: uroot bzImage
-	cp linux/arch/x86/boot/bzImage flashkernel
-
-netboot: netbooturoot bzImage
-	cp linux/arch/x86/boot/bzImage kernel
-
-readrom:
-	echo You need to get a ROM image from *somewhere*
-	echo Once you do, put it in ROM.bin
-
-writerom: image.bin
-	echo Here is where you would do the flashrom, e.g.
-	echo sudo flashrom -p dediprog -w image.bin
-
-netbooturoot:
-	go run github.com/u-root/u-root  -o linux/initramfs.linux_amd64.cpio -build=bb github.com/u-root/u-root/cmds/core/init github.com/u-root/u-root/cmds/core/ls github.com/u-root/u-root/cmds/core/ip   github.com/u-root/u-root/cmds/core/elvish    github.com/u-root/u-root/cmds/core/sshd    github.com/u-root/u-root/cmds/core/scp github.com/u-root/u-root/cmds/boot/*
-
-uroot.lzma: uroot
-	lzma -f -k initramfs.linux_amd64.cpio
-
-uroot:
-	go run github.com/u-root/u-root -o initramfs.linux_amd64.cpio -build=bb -initcmd=cpud -files ~/.ssh/cpu_rsa.pub:key.pub \
-		-defaultsh="" \
-		github.com/u-root/cpu/cmds/cpud
-
-alluroot:
-	go run github.com/u-root/u-root -o initramfs.linux_amd64.cpio -build=bb -initcmd=cpud -files ~/.ssh/cpu_rsa.pub:key.pub \
-		github.com/u-root/cpu/cmds/cpud \
-		all
-	lzma -k -f initramfs.linux_amd64.cpio
-	ls -l initramfs*
-	cp *lzma linux
-
-bzImage:
-	cp linuxboot-linux.config linux/.config
-	(cd linux && make oldconfig && make -j32)
-
-stablebzImage:
-	echo the config is from https://github.com/emutex/ubilinux-kernel/issues/2#issue-294853930
-	cp ts.config.txt linux/.config
-	(cd linux && make oldconfig && make -j32)
-
-fetch: getkernel geturoot getfiano getrom
+fetch: getrom prepgows getfiano getkernel
 
 getkernel:
 	rm -rf linux
@@ -107,14 +25,122 @@ upgetkernel:
 	rm -rf linux
 	git clone --depth=1 https://github.com/emutex/ubilinux-kernel.git -b upboard-4.9 linux
 
+# Set up the Go workspace, including cpu.
+# see https://github.com/u-root/u-root?tab=readme-ov-file#multi-module-workspace-builds
+# NOTE: goanywhere is nice, but how would we combine cpud and u-root templates?
+prepgows:
+	git clone --depth 1 https://github.com/u-root/u-root
+	git clone --depth 1 https://github.com/u-root/cpu
+	go work init ./u-root
+	go work use ./cpu
+
 getfiano:
-	go get -u github.com/linuxboot/fiano/cmds/utk
-	go install github.com/linuxboot/fiano/cmds/utk
+	go install github.com/linuxboot/fiano/cmds/utk@latest
+
+# initramfs
+
+alluroot:
+	cd u-root && go run . -o $(INITRAMFS) \
+		-initcmd=cpud -files ~/.ssh/cpu_rsa.pub:key.pub ../cpu/cmds/cpud \
+		all
+
+cpuuroot:
+	cd u-root && go run . -o $(INITRAMFS) \
+		-defaultsh="" \
+		-initcmd=cpud -files ~/.ssh/cpu_rsa.pub:key.pub ../cpu/cmds/cpud
+
+# TODO: Should we use a template instead? Or define one in this repo?
+# https://github.com/u-root/u-root/blob/main/.mkuimage.yaml
+neturoot:
+	cd u-root && go run . -o $(INITRAMFS) \
+		./cmds/core/init \
+		./cmds/core/ls \
+		./cmds/core/ip \
+		./cmds/core/gosh \
+		./cmds/core/sshd \
+		./cmds/core/scp \
+		./cmds/boot/*
+
+uroot.lzma:
+	lzma -f -k ./u-root/$(INITRAMFS)
+	ls -l u-root/initramfs*
+	cp u-root/*lzma linux
+
+# Linux
+
+# FIXME: The current config does not include the initramfs. Should it?
+bzImage:
+	cp linuxboot-linux.config linux/.config
+	(cd linux && make oldconfig && make -j32)
+
+stablebzImage:
+	echo "the config is from https://github.com/emutex/ubilinux-kernel/issues/2#issue-294853930"
+	cp ts.config.txt linux/.config
+	(cd linux && make oldconfig && make -j32)
+
+flashkernel: cpuuroot uroot.lzma bzImage
+	cp linux/arch/x86/boot/bzImage flashkernel
+
+netboot: neturoot uroot.lzma bzImage
+	cp linux/arch/x86/boot/bzImage kernel
+
+# ROM operations
+
+image.bin:  
+	utk -xzPath /usr/bin/xz \
+		ROM.bin \
+		remove Nb.* \
+		remove IntelIsh.* \
+	  remove Ip.*  \
+    remove Tcp.*  \
+    remove Usb.*  \
+    remove Udp.*  \
+    remove Dhcp.*  \
+    remove .np.*  \
+    remove .tftp.*  \
+    remove Http.* \
+    remove .*Dns.* \
+    remove Arp.* \
+    remove .*NetworkStackSetupScreen.*  \
+    remove Iscsi.* \
+    remove Scsi.* \
+    remove Fat.* \
+    remove Ahci.* \
+    remove Partition.* \
+    remove Sata.* \
+    remove Disk.* \
+    remove Whea.* \
+    remove .*Pxe.* \
+    remove Ata.* \
+		remove AmiSeri.* \
+		remove IntelGop.* \
+		remove Logo.* \
+		remove Mouse.* \
+		remove .*Keyboard.* \
+		remove FlashDriver \
+		remove HiiDataBase \
+		remove EbcDxe \
+		remove AMITSE \
+		remove AMITSE.* \
+		remove Mmc.* \
+		remove Tcg.* \
+		remove Ish.* \
+		remove Setup \
+		save image.bin
+	utk image.bin table | guid2english | grep Free
+	# FIXME: What is this?
+	echo remove AmiTc.*
+	echo need 0x16b4a0
+
 getrom:
 	echo you can put a wget here
 	echo and unxip it 
 	echo and cp it to sr630.bin
-geturoot:
-	go get -u github.com/u-root/u-root
-	go get -u github.com/u-root/cpu/...
 
+readrom:
+	echo You need to get a ROM image from *somewhere*
+	echo Once you do, put it in ROM.bin
+
+writerom: image.bin
+	echo Here is where you would do the flashrom, e.g.
+	echo sudo flashrom -p dediprog -w image.bin


### PR DESCRIPTION
Keeping actions on a recent version is necessary because older ones are deprecated over time and would at some point error. We have seen such errors already, so this upgrades all actions.

resolves #94