### PR TITLE
ampere/jade: Fix CI

### DIFF
--- a/mainboards/ampere/jade/Makefile
+++ b/mainboards/ampere/jade/Makefile
@@ -21,16 +21,20 @@ flashinitramfs.cpio.lzma: flashinitramfs.cpio
 	lzma -f -k $<
 
 flashinitramfs.cpio: Makefile
-	GO111MODULE=off GOARCH=arm64 u-root -uroot-source ${GOPATH}/src/github.com/u-root/u-root -uinitcmd=systemboot -o $@ core \
-		github.com/u-root/u-root/cmds/boot/systemboot \
-		github.com/u-root/u-root/cmds/boot/localboot \
-		github.com/u-root/u-root/cmds/boot/fbnetboot \
-		github.com/u-root/u-root/cmds/exp/acpicat \
-		github.com/u-root/u-root/cmds/exp/acpigrep \
-		github.com/u-root/u-root/cmds/exp/disk_unlock \
-		github.com/u-root/u-root/cmds/exp/dmidecode \
-		github.com/u-root/u-root/cmds/exp/ipmidump \
-		github.com/u-root/cpu/cmds/cpud
+	cd u-root && go build . && GOARCH=arm64 ./u-root -uinitcmd="boot" -o $@ \
+		./cmds/core/* \
+		./cmds/boot/* \
+		./cmds/exp/systemboot \
+		./cmds/exp/localboot \
+		./cmds/exp/fbnetboot \
+		./cmds/exp/dmidecode \
+		./cmds/exp/acpicat \
+		./cmds/exp/acpigrep \
+		./cmds/exp/disk_unlock \
+		./cmds/exp/dmidecode \
+		./cmds/exp/ipmidump \
+		../cpu/cmds/cpud
+	cp u-root/flashinitramfs.cpio .
 
 # this target builds an initramfs with only one program, the cpu server.
 # It depends on the kernel setting the IP address.
@@ -79,8 +83,12 @@ getkernel:
 	(cd linux && ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- make tinyconfig)
 
 geturoot:
-	GO111MODULE=off go get -u github.com/u-root/u-root
-	GO111MODULE=off go get -u github.com/u-root/cpu/...
+	rm -rf u-root cpu
+	git clone --depth 1 https://github.com/u-root/u-root
+	git clone --depth 1 https://github.com/u-root/cpu
+	rm -f go.*
+	go work init ./u-root
+	go work use ./cpu
 
 # Serve the combined sshd-kernel and sshd-initramfs image. This includes flashrom
 sshd-pxeserver:


### PR DESCRIPTION
This is to use `go work` commands for multi-module workspace build.