### PR TITLE
mainboards: fix CI Matrix Badgers in the README.md

### DIFF
--- a/mainboards/README.md
+++ b/mainboards/README.md
@@ -3,4 +3,4 @@ linuxboot for various mainboards
 
 ## Latest Build Status
 
-[![](http://github-actions.40ants.com/linuxboot/mainboards/matrix.svg)](https://github.com/linuxboot/mainboards)
+[![](http://github-actions.40ants.com/linuxboot/linuxboot/matrix.svg)](https://github.com/linuxboot/linuxboot)


### PR DESCRIPTION
This corrects the badger link to linuxboot/linuxboot repository to reflect the integration of the mainboards folder from the linuxboot/mainboards repository.